### PR TITLE
feat(api-booking): add booking repository with custom query methods

### DIFF
--- a/api-booking/src/main/java/com/wingtrip/booking/repository/BookingRepository.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/repository/BookingRepository.java
@@ -1,0 +1,19 @@
+package com.wingtrip.booking.repository;
+
+import com.wingtrip.booking.model.BookingEntity;
+import com.wingtrip.booking.model.BookingStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
+
+    Optional<BookingEntity> findByBookingReference(String reference);
+    List<BookingEntity> findByUserId(Long userId);
+    List<BookingEntity> findByUserIdAndBookingStatus(Long userId, BookingStatus bookingStatus);
+    List<BookingEntity> findByFlightId(Long flightId);
+
+}


### PR DESCRIPTION
## Changes
Implementa la capa de persistencia para api-booking.

### Added
- `BookingRepository` - Interface JPA que extiende `JpaRepository<BookingEntity, Long>`

### Custom Query Methods
- `findByBookingReference(String)` - Buscar reserva por referencia única
- `findByUserId(Long)` - Obtener todas las reservas de un usuario
- `findByUserIdAndBookingStatus(Long, BookingStatus)` - Filtrar reservas por usuario y estado
- `findByFlightId(Long)` - Obtener reservas de un vuelo específico

### Technical Details
- Extiende `JpaRepository` para operaciones CRUD automáticas
- Métodos de consulta derivados (JPA genera queries automáticamente)
- Sigue el mismo patrón que `UserRepository` en api-user

## Next Steps
- Implementar `BookingService` (lógica de negocio)
- Implementar `BookingServiceImpl` (implementación del servicio)
- Agregar validaciones y manejo de excepciones
