### PR TITLE
feat(api-booking): complete booking microservice implementation

### DIFF
--- a/.env
+++ b/.env
@@ -1,7 +1,13 @@
-# Mysql Configuration
+# DATABASE_ROOT_PASSWORD
 DATABASE_ROOT_PASSWORD=rootpassword123
-DATABASE_USERNAME=wingtrip_user
-DATABASE_PASSWORD=1324
+
+# Configuración para API-USER
+USER_DB_USER=wingtrip_user
+USER_DB_PASS=1324
+
+# Configuración para API-BOOKING
+BOOKING_DB_USER=wingtrip_booking
+BOOKING_DB_PASS=1324
 
 # RabbitMQ Configuration
 RABBITMQ_USERNAME=admin

--- a/api-booking/Dockerfile
+++ b/api-booking/Dockerfile
@@ -1,0 +1,5 @@
+FROM eclipse-temurin:17-jdk
+WORKDIR /app
+COPY target/*.jar app.jar
+EXPOSE 8080
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/api-booking/pom.xml
+++ b/api-booking/pom.xml
@@ -17,6 +17,8 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <lombok.version>1.18.30</lombok.version>
         <org.mapstruct.version>1.5.5.Final</org.mapstruct.version>
+        <jacoco.version>0.8.8</jacoco.version>
+        <jacoco.minimum.coverage>0.70</jacoco.minimum.coverage>
     </properties>
 
     <dependencies>
@@ -193,6 +195,81 @@
                             <artifactId>lombok</artifactId>
                         </exclude>
                     </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Plugin para Jococo -->
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>${jacoco.version}</version>
+                <executions>
+                    <!-- Preparar agente para tests -->
+                    <execution>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Generar reporte después de tests -->
+                    <execution>
+                        <id>report</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+
+                    <!-- Verificar coverage mínimo -->
+                    <execution>
+                        <id>check</id>
+                        <goals>
+                            <goal>check</goal>
+                        </goals>
+                        <configuration>
+                            <rules>
+                                <rule>
+                                    <element>BUNDLE</element>
+                                    <limits>
+                                        <limit>
+                                            <counter>LINE</counter>
+                                            <value>COVEREDRATIO</value>
+                                            <minimum>${jacoco.minimum.coverage}</minimum>
+                                        </limit>
+                                    </limits>
+                                </rule>
+                            </rules>
+                        </configuration>
+                    </execution>
+                </executions>
+
+                <configuration>
+                    <!-- Excluir clases que no necesitan coverage -->
+                    <excludes>
+                        <exclude>**/dto/**</exclude>
+                        <exclude>**/model/**</exclude>
+                        <exclude>**/controller/response/**</exclude>
+                        <exclude>**/controller/request/**</exclude>
+                        <exclude>**/config/**</exclude>
+                        <exclude>**/constant/**</exclude>
+                        <exclude>**/util/**</exclude>
+                        <exclude>**/ApiBookingApplication.class</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+
+            <!-- Plugin maven surfire -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>3.0.0</version>
+                <configuration>
+                    <!-- Generar reportes XML para GitLab -->
+                    <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
+                    <includes>
+                        <include>**/*Test.java</include>
+                        <include>**/*Tests.java</include>
+                    </includes>
                 </configuration>
             </plugin>
         </plugins>

--- a/api-booking/pom.xml
+++ b/api-booking/pom.xml
@@ -120,18 +120,34 @@
         </dependency>
 
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.jeasy</groupId>
             <artifactId>easy-random-core</artifactId>
             <version>5.0.0</version>
             <scope>test</scope>
         </dependency>
 
+        <!-- H2 Database for Tests -->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <scope>test</scope>
+        </dependency>
+
         <!-- Validation Dependencies -->
         <dependency>
-            <groupId>javax.validation</groupId>
-            <artifactId>validation-api</artifactId>
-            <version>2.0.1.Final</version>
-            <scope>compile</scope>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-validation</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>com.fasterxml.jackson.datatype</groupId>
+            <artifactId>jackson-datatype-jsr310</artifactId>
         </dependency>
 
         <!-- Swagger Dependencies -->

--- a/api-booking/postman/WingTrip-API-Booking.postman_collection.json
+++ b/api-booking/postman/WingTrip-API-Booking.postman_collection.json
@@ -1,0 +1,394 @@
+{
+  "info": {
+    "_postman_id": "64b2d2f8-734e-43b7-ac7a-5f61011c530f",
+    "name": "WingTrip-API-Booking",
+    "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
+    "_exporter_id": "18573665"
+  },
+  "item": [
+    {
+      "name": "Create booking",
+      "request": {
+        "method": "POST",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"userId\": 1,\r\n  \"flightId\": 101,\r\n  \"travelDate\": \"2025-08-15\",\r\n  \"returnDate\": \"2025-08-22\",\r\n  \"adultPassengers\": 2,\r\n  \"childPassengers\": 0,\r\n  \"infantPassengers\": 0,\r\n  \"totalAmount\": 450.00,\r\n  \"currency\": \"USD\",\r\n  \"specialRequests\": \"Window seats preferred\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/create",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "create"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Find booking by id",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/find/6",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "find",
+            "6"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Update booking by id",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "body": {
+          "mode": "raw",
+          "raw": "{\r\n  \"userId\": 1,\r\n  \"flightId\": 101,\r\n  \"travelDate\": \"2025-08-15\",\r\n  \"returnDate\": \"2025-08-22\",\r\n  \"adultPassengers\": 3,\r\n  \"childPassengers\": 1,\r\n  \"infantPassengers\": 0,\r\n  \"totalAmount\": 450.00,\r\n  \"currency\": \"USD\",\r\n  \"specialRequests\": \"Extra legroom and vegetarian meal\",\r\n  \"bookingNotes\": \"Updated request\"\r\n}",
+          "options": {
+            "raw": {
+              "language": "json"
+            }
+          }
+        },
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/update/1",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "update",
+            "1"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Find by reference",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/find-by-reference/WT4AC402",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "find-by-reference",
+            "WT4AC402"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Confirm Booking",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/confirm/6?paymentId=1001",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "confirm",
+            "6"
+          ],
+          "query": [
+            {
+              "key": "paymentId",
+              "value": "1001"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Cancel Booking",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/cancel/1",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "cancel",
+            "1"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Expired booking",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/is-expired/1",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "is-expired",
+            "1"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Finds bookings by user ID",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/user/4",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "user",
+            "4"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Finds bookings by user ID and status",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/user/1/status?status=CONFIRMED",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "user",
+            "1",
+            "status"
+          ],
+          "query": [
+            {
+              "key": "status",
+              "value": "CONFIRMED",
+              "type": "text"
+            }
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Finds cancelled bookings by user ID",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/user/4/cancelled",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "user",
+            "4",
+            "cancelled"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Finds pending bookings by user ID",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/user/2/pending",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "user",
+            "2",
+            "pending"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Finds expired bookings by user ID",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/user/2/expired",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "user",
+            "2",
+            "expired"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Finds all expired bookings",
+      "request": {
+        "method": "GET",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/expired",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "expired"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Mark as expired",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/mark-expired/1",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "mark-expired",
+            "1"
+          ]
+        }
+      },
+      "response": []
+    },
+    {
+      "name": "Mark as paid",
+      "request": {
+        "method": "PUT",
+        "header": [],
+        "url": {
+          "raw": "http://localhost:8082/api/v1/booking/mark-paid/6?paymentId=1001",
+          "protocol": "http",
+          "host": [
+            "localhost"
+          ],
+          "port": "8082",
+          "path": [
+            "api",
+            "v1",
+            "booking",
+            "mark-paid",
+            "6"
+          ],
+          "query": [
+            {
+              "key": "paymentId",
+              "value": "1001"
+            }
+          ]
+        }
+      },
+      "response": []
+    }
+  ]
+}

--- a/api-booking/src/main/java/com/wingtrip/booking/config/SwaggerConfig.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/config/SwaggerConfig.java
@@ -1,0 +1,37 @@
+package com.wingtrip.booking.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Contact;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.util.List;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Value("${server.port:8080}")
+    private String serverPort;
+
+    @Value("${spring.application.name:api-booking}")
+    private String applicationName;
+
+    @Bean
+    public OpenAPI customOpenAPI() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("API Booking Service")
+                        .version("1.0.0")
+                        .description("API para gestión de reservas")
+                        .contact(new Contact()
+                                .name("wingtrip")
+                                .email("wingtrip@example.com")))
+                .servers(List.of(
+                        new Server().url("http://localhost:8080").description("Local server"),
+                        new Server().url("http://api-booking:8080").description("Docker server")
+                ));
+    }
+}

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/BookingController.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/BookingController.java
@@ -1,0 +1,202 @@
+package com.wingtrip.booking.controller;
+
+import com.wingtrip.booking.controller.doc.BookingControllerDoc;
+import com.wingtrip.booking.controller.mapper.BookingMapper;
+import com.wingtrip.booking.controller.request.CreateBookingRequest;
+import com.wingtrip.booking.controller.request.UpdateBookingRequest;
+import com.wingtrip.booking.controller.response.BookingResponse;
+import com.wingtrip.booking.dto.BookingDTO;
+import com.wingtrip.booking.exception.*;
+import com.wingtrip.booking.model.BookingStatus;
+import com.wingtrip.booking.service.impl.BookingServiceImpl;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping(path = "/api/v1/booking")
+public class BookingController implements BookingControllerDoc {
+
+    private final BookingMapper bookingMapper;
+    private final BookingServiceImpl bookingService;
+
+    @PostMapping("/create")
+    public ResponseEntity<BookingResponse> createBooking(@Valid @RequestBody CreateBookingRequest createRequest) throws BookingNotCreateException {
+        log.info("Create new booking request received: {}", createRequest);
+        BookingDTO bookingDTO = bookingMapper.toDTO(createRequest);
+        BookingDTO createdBooking = bookingService.createBooking(bookingDTO);
+        BookingResponse bookingResponse = bookingMapper.toResponse(createdBooking);
+        log.info("Booking created successfully: {}", bookingResponse);
+        return ResponseEntity.status(HttpStatus.CREATED).body(bookingResponse);
+    }
+
+    @Override
+    @PutMapping("/update/{bookingId}")
+    public ResponseEntity<BookingResponse> updateBooking(@PathVariable Long bookingId, @Valid @RequestBody UpdateBookingRequest updateRequest) throws BookingNotUpdateException, BookingAlreadyCancelledException {
+        log.info("Updating booking with ID {}:", bookingId);
+        BookingDTO updatedBooking = bookingService.updateBooking(bookingId, updateRequest);
+        BookingResponse bookingResponse = bookingMapper.toResponse(updatedBooking);
+        log.info("Booking updated successfully with ID: {}", bookingId);
+        return ResponseEntity.ok(bookingResponse);
+    }
+
+    @Override
+    @GetMapping("/find/{bookingId}")
+    public ResponseEntity<BookingResponse> findById(@PathVariable Long bookingId) throws BookingNotFoundByIdException {
+        log.info("Finding booking with ID {}:", bookingId);
+        BookingDTO bookingDTO = bookingService.findById(bookingId);
+        BookingResponse bookingResponse = bookingMapper.toResponse(bookingDTO);
+        log.info("Booking found successfully with ID: {}", bookingId);
+        return ResponseEntity.ok(bookingResponse);
+    }
+
+    @Override
+    @GetMapping("/find-by-reference/{bookingReference}")
+    public ResponseEntity<BookingResponse> findByReference(@PathVariable String bookingReference) throws BookingNotFoundByReferenceException {
+        log.info("Finding booking with reference {}:", bookingReference);
+        BookingDTO bookingDTO = bookingService.findByReference(bookingReference);
+        BookingResponse bookingResponse = bookingMapper.toResponse(bookingDTO);
+        log.info("Booking found successfully with reference: {}", bookingReference);
+        return ResponseEntity.ok(bookingResponse);
+    }
+
+    @Override
+    @PutMapping("/confirm/{bookingId}")
+    public ResponseEntity<BookingResponse> confirmBooking(@PathVariable Long bookingId, @RequestParam Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException {
+        log.info("Confirming booking with ID: {} and payment ID: {}", bookingId, paymentId);
+        bookingService.confirmBooking(bookingId, paymentId);
+        BookingDTO bookingDTO = bookingService.findById(bookingId);
+        BookingResponse bookingResponse = bookingMapper.toResponse(bookingDTO);
+        log.info("Booking confirmed successfully with ID: {}", bookingId);
+        return ResponseEntity.ok(bookingResponse);
+    }
+
+    @Override
+    @PutMapping("/cancel/{bookingId}")
+    public ResponseEntity<BookingResponse> cancelBooking(@PathVariable Long bookingId) throws BookingCannotBeCancelledException, BookingAlreadyCancelledException, BookingNotFoundByIdException {
+        log.info("Cancelling booking with ID: {}", bookingId);
+        bookingService.cancelBooking(bookingId);
+        BookingDTO bookingDTO = bookingService.findById(bookingId);
+        BookingResponse bookingResponse = bookingMapper.toResponse(bookingDTO);
+        log.info("Booking cancelled successfully with ID: {}", bookingId);
+        return ResponseEntity.ok(bookingResponse);
+    }
+
+    @Override
+    @GetMapping("/is-expired/{bookingId}")
+    public ResponseEntity<BookingResponse> isBookingExpired(@PathVariable Long bookingId) {
+        log.info("Checking if booking with ID: {} is expired", bookingId);
+        boolean isExpired = bookingService.isBookingExpired(bookingId);
+        try {
+            BookingDTO bookingDTO = bookingService.findById(bookingId);
+            BookingResponse bookingResponse = bookingMapper.toResponse(bookingDTO);
+            log.info("Booking expiration status: {}", isExpired);
+            return ResponseEntity.ok(bookingResponse);
+        } catch (BookingNotFoundByIdException ex) {
+            log.error("Booking not found with ID: {}", bookingId);
+            throw new RuntimeException(ex);
+        }
+    }
+
+    @Override
+    @GetMapping("/user/{userId}")
+    public ResponseEntity<List<BookingResponse>> findBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException {
+        log.info("Finding bookings for user ID: {}", userId);
+        List<BookingDTO> bookings = bookingService.findBookingsByUserId(userId);
+        List<BookingResponse> responses = bookings.stream()
+                .map(bookingMapper::toResponse)
+                .collect(Collectors.toList());
+        log.info("Found {} bookings for user ID: {}", responses.size(), userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Override
+    @GetMapping("/user/{userId}/status")
+    public ResponseEntity<List<BookingResponse>> findBookingsByUserIdAndStatus(@PathVariable Long userId, @RequestParam BookingStatus status) throws UserBookingsNotFoundException {
+        log.info("Finding bookings for user ID: {} with status: {}", userId, status);
+        List<BookingDTO> bookings = bookingService.findBookingsByUserIdAndStatus(userId, status);
+        List<BookingResponse> responses = bookings.stream()
+                .map(bookingMapper::toResponse)
+                .collect(Collectors.toList());
+        log.info("Found {} bookings for user ID: {} with status: {}", responses.size(), userId, status);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Override
+    @GetMapping("/user/{userId}/cancelled")
+    public ResponseEntity<List<BookingResponse>> findCancelledBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException {
+        log.info("Finding cancelled bookings for user ID: {}", userId);
+        List<BookingDTO> bookings = bookingService.findCancelledBookingsByUserId(userId);
+        List<BookingResponse> responses = bookings.stream()
+                .map(bookingMapper::toResponse)
+                .collect(Collectors.toList());
+        log.info("Found {} cancelled bookings for user ID: {}", responses.size(), userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Override
+    @GetMapping("/user/{userId}/pending")
+    public ResponseEntity<List<BookingResponse>> findPendingBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException {
+        log.info("Finding pending bookings for user ID: {}", userId);
+        List<BookingDTO> bookings = bookingService.findPendingBookingsByUserId(userId);
+        List<BookingResponse> responses = bookings.stream()
+                .map(bookingMapper::toResponse)
+                .collect(Collectors.toList());
+        log.info("Found {} pending bookings for user ID: {}", responses.size(), userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Override
+    @GetMapping("/user/{userId}/expired")
+    public ResponseEntity<List<BookingResponse>> findExpiredBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException {
+        log.info("Finding expired bookings for user ID: {}", userId);
+        List<BookingDTO> bookings = bookingService.findExpiredBookingsByUserId(userId);
+        List<BookingResponse> responses = bookings.stream()
+                .map(bookingMapper::toResponse)
+                .collect(Collectors.toList());
+        log.info("Found {} expired bookings for user ID: {}", responses.size(), userId);
+        return ResponseEntity.ok(responses);
+    }
+
+    @Override
+    @GetMapping("/expired")
+    public ResponseEntity<List<BookingResponse>> findAllExpiredBookings() {
+        log.info("Finding all expired bookings");
+        List<BookingDTO> bookings = bookingService.findAllExpiredBookings();
+        List<BookingResponse> responsesList = bookings.stream()
+                .map(bookingMapper::toResponse)
+                .collect(Collectors.toList());
+        log.info("Found {} expired bookings in total", responsesList.size());
+        return ResponseEntity.ok(responsesList);
+    }
+
+    @Override
+    @PutMapping("/mark-expired/{bookingId}")
+    public ResponseEntity<BookingResponse> markAsExpired(@PathVariable Long bookingId) throws BookingExpiredException, BookingNotFoundByIdException {
+        log.info("Marking booking with ID: {} as expired", bookingId);
+        bookingService.markAsExpired(bookingId);
+        BookingDTO bookingDTO = bookingService.findById(bookingId);
+        BookingResponse bookingResponse = bookingMapper.toResponse(bookingDTO);
+        log.info("Booking marked as expired successfully with ID: {}", bookingId);
+        return ResponseEntity.ok(bookingResponse);
+    }
+
+    @Override
+    @PutMapping("/mark-paid/{bookingId}")
+    public ResponseEntity<BookingResponse> markAsPaid(@PathVariable Long bookingId, @RequestParam Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException {
+        log.info("Marking booking with ID: {} as paid with payment ID: {}", bookingId, paymentId);
+        bookingService.markAsPaid(bookingId, paymentId);
+        BookingDTO bookingDTO = bookingService.findById(bookingId);
+        BookingResponse bookingResponse = bookingMapper.toResponse(bookingDTO);
+        log.info("Booking marked as paid successfully with ID: {}", bookingId);
+        return ResponseEntity.ok(bookingResponse);
+    }
+}

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/doc/BookingControllerDoc.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/doc/BookingControllerDoc.java
@@ -1,0 +1,319 @@
+package com.wingtrip.booking.controller.doc;
+
+import com.wingtrip.booking.controller.request.CreateBookingRequest;
+import com.wingtrip.booking.controller.request.UpdateBookingRequest;
+import com.wingtrip.booking.controller.response.BookingResponse;
+import com.wingtrip.booking.exception.*;
+import com.wingtrip.booking.model.BookingStatus;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+
+import javax.validation.Valid;
+import java.util.List;
+
+@Tag(name = "Booking Controller", description = "Endpoints for managing bookings")
+public interface BookingControllerDoc {
+
+
+    @Operation(summary = "Created new booking",
+            description = "Creates a new booking in the system.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "201",
+                    description = "Booking created successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "500",
+                    description = "Error creating booking",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> createBooking(@Valid @RequestBody CreateBookingRequest bookingRequest) throws BookingNotCreateException;
+
+    @Operation(summary = "Update booking by user",
+            description = "Updates an existing booking's information using their user.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "User updated successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Booking not found",
+                    content = @Content
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid update data",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> updateBooking(@PathVariable Long bookingId, @RequestBody UpdateBookingRequest updateRequest) throws BookingNotUpdateException, BookingAlreadyCancelledException;
+
+    @Operation(summary = "Search booking by ID",
+            description = "Search and return the information for a specific booking using their unique ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Booking found successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Booking not found with the provided ID",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> findById(@PathVariable Long bookingId) throws BookingNotFoundByIdException;
+
+    @Operation(summary = "Search user by reference",
+            description = "Search and return the information for a booking using their reference.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Booking found successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Booking not found with the provided reference",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> findByReference(@PathVariable String bookingReference) throws BookingNotFoundByReferenceException;
+
+    @Operation(summary = "Confirm booking by ID",
+            description = "Confirm a booking using their unique ID and Payment ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Confirmation completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Confirmation failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> confirmBooking(@PathVariable Long bookingId, Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException;
+
+    @Operation(summary = "Cancel booking by ID",
+            description = "Cancel a booking using their unique ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Cancellation completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Cancellation failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> cancelBooking(@PathVariable Long bookingId) throws BookingCannotBeCancelledException, BookingAlreadyCancelledException, BookingNotFoundByIdException;
+
+
+    @Operation(summary = "Expired booking by ID",
+            description = "Expire a booking using their unique ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Expiration completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Expiration failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> isBookingExpired(@PathVariable Long bookingId);
+
+    @Operation(summary = "Find bookings by user ID",
+            description = "Search and return all bookings associated with a specific user ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Bookings found successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Bookings not found for the provided user ID",
+                    content = @Content
+            )
+    })
+    ResponseEntity<List<BookingResponse>> findBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException;
+
+    @Operation(summary = "Find bookings by user ID and status",
+            description = "Search and return all bookings associated with a specific user ID and booking status.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Bookings found successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Bookings not found for the provided user ID and status",
+                    content = @Content
+            )
+    })
+    ResponseEntity<List<BookingResponse>> findBookingsByUserIdAndStatus(@PathVariable Long userId, BookingStatus status) throws UserBookingsNotFoundException;
+
+    @Operation(summary = "Cancel booking by ID",
+            description = "Cancel a booking using their unique ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Cancellation completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Cancellation failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<List<BookingResponse>> findCancelledBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException;
+
+    @Operation(summary = "Pending booking by ID",
+            description = "Pending a booking using their unique ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Pending completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Pending failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<List<BookingResponse>> findPendingBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException;
+
+    @Operation(summary = "Expired booking by ID",
+            description = "Expire a booking using their unique ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Expiration completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Expiration failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<List<BookingResponse>> findExpiredBookingsByUserId(@PathVariable Long userId) throws UserBookingsNotFoundException;
+
+
+    @Operation(summary = "Find all expired bookings",
+            description = "Find and return all bookings that have expired in the system.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Find completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Find failed, no expired bookings found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<List<BookingResponse>> findAllExpiredBookings();
+
+
+    @Operation(summary = "Mark booking as expired by ID",
+            description = "Mark a booking as expired using their unique ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Find completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Marking failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> markAsExpired(@PathVariable Long bookingId) throws BookingExpiredException, BookingNotFoundByIdException;
+
+    @Operation(summary = "Mark booking as paid by ID",
+            description = "Mark a booking as paid using their unique ID and Payment ID.")
+    @ApiResponses(value = {
+            @ApiResponse(
+                    responseCode = "200",
+                    description = "Find completed successfully",
+                    content = @Content(
+                            mediaType = "application/json",
+                            schema = @Schema(implementation = BookingResponse.class)
+                    )
+            ),
+            @ApiResponse(
+                    responseCode = "404",
+                    description = "Marking failed, booking not found",
+                    content = @Content
+            )
+    })
+    ResponseEntity<BookingResponse> markAsPaid(@PathVariable Long bookingId, Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException;
+}
+
+

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/doc/BookingControllerDoc.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/doc/BookingControllerDoc.java
@@ -11,12 +11,13 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestParam;
 
-import javax.validation.Valid;
+
 import java.util.List;
 
 @Tag(name = "Booking Controller", description = "Endpoints for managing bookings")

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/doc/BookingControllerDoc.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/doc/BookingControllerDoc.java
@@ -14,6 +14,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 import javax.validation.Valid;
 import java.util.List;
@@ -32,6 +33,11 @@ public interface BookingControllerDoc {
                             mediaType = "application/json",
                             schema = @Schema(implementation = BookingResponse.class)
                     )
+            ),
+            @ApiResponse(
+                    responseCode = "400",
+                    description = "Invalid request data",
+                    content = @Content
             ),
             @ApiResponse(
                     responseCode = "500",
@@ -120,7 +126,7 @@ public interface BookingControllerDoc {
                     content = @Content
             )
     })
-    ResponseEntity<BookingResponse> confirmBooking(@PathVariable Long bookingId, Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException;
+    ResponseEntity<BookingResponse> confirmBooking(@PathVariable Long bookingId, @RequestParam Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException;
 
     @Operation(summary = "Cancel booking by ID",
             description = "Cancel a booking using their unique ID.")
@@ -197,7 +203,7 @@ public interface BookingControllerDoc {
                     content = @Content
             )
     })
-    ResponseEntity<List<BookingResponse>> findBookingsByUserIdAndStatus(@PathVariable Long userId, BookingStatus status) throws UserBookingsNotFoundException;
+    ResponseEntity<List<BookingResponse>> findBookingsByUserIdAndStatus(@PathVariable Long userId, @RequestParam BookingStatus status) throws UserBookingsNotFoundException;
 
     @Operation(summary = "Cancel booking by ID",
             description = "Cancel a booking using their unique ID.")
@@ -313,7 +319,7 @@ public interface BookingControllerDoc {
                     content = @Content
             )
     })
-    ResponseEntity<BookingResponse> markAsPaid(@PathVariable Long bookingId, Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException;
+    ResponseEntity<BookingResponse> markAsPaid(@PathVariable Long bookingId, @RequestParam Long paymentId) throws BookingNotUpdateException, BookingNotFoundByIdException;
 }
 
 

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/errorhandling/GlobalExceptionHandler.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/errorhandling/GlobalExceptionHandler.java
@@ -43,34 +43,23 @@ public class GlobalExceptionHandler {
         result.put(STATUS, HttpStatus.BAD_REQUEST.value());
         result.put(ERROR, ex.getMessage());
         result.put(PATH, new UrlPathHelper().getPathWithinApplication(req));
-        log.error("Custom exception ocurred: {}" + ERROR, ex.getMessage());
+
+        log.error("Custom business exception ocurred: {} at path: {}", ex.getMessage(), result.get(PATH));
+
         return new ResponseEntity<>(result, HttpStatus.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
     public ResponseEntity<Map<String, Object>> handleGenericException(HttpServletRequest req, Exception ex) {
 
-        if (ex instanceof BookingNotFoundException ||
-                ex instanceof BookingNotFoundByIdException ||
-                ex instanceof BookingNotFoundByReferenceException ||
-                ex instanceof UserBookingsNotFoundException ||
-                ex instanceof BookingNotCreateException ||
-                ex instanceof BookingNotUpdateException ||
-                ex instanceof BookingAlreadyCancelledException ||
-                ex instanceof BookingExpiredException ||
-                ex instanceof BookingCannotBeCancelledException ||
-                ex instanceof InvalidBookingDatesException ||
-                ex instanceof InvalidPassengerCountException ||
-                ex instanceof FlightNotAvailableException) {
-            return null;
-        }
-
         Map<String, Object> result = new HashMap<>();
-        result.put(TIMESTAMP, DateTimeUtil.now().toEpochDay());
+        result.put(TIMESTAMP, System.currentTimeMillis());
         result.put(STATUS, HttpStatus.INTERNAL_SERVER_ERROR.value());
         result.put(ERROR, ex.getMessage());
         result.put(PATH, new UrlPathHelper().getPathWithinApplication(req));
-        log.error("Generic exception occurred: {}" + ERROR, ex.getMessage());
+
+        log.error("Unexpected error occurred: {} at path: {}", ex.getMessage(), result.get(PATH), ex);
+
         return new ResponseEntity<>(result, HttpStatus.INTERNAL_SERVER_ERROR);
     }
 }

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/request/CreateBookingRequest.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/request/CreateBookingRequest.java
@@ -31,6 +31,8 @@ public class CreateBookingRequest {
 
     private int infantPassengers;
 
+    private Double totalAmount;
+
     private String currency; // Opcional, default "USD"
 
     private String specialRequests; // Opcional

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingResponse.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingResponse.java
@@ -1,5 +1,6 @@
 package com.wingtrip.booking.controller.response;
 
+import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wingtrip.booking.model.BookingStatus;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -11,6 +12,7 @@ import java.time.LocalDateTime;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
 public class BookingResponse {
 
     private Long bookingId;

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingResponse.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingResponse.java
@@ -3,6 +3,7 @@ package com.wingtrip.booking.controller.response;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.wingtrip.booking.model.BookingStatus;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
@@ -12,6 +13,7 @@ import java.time.LocalDateTime;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
+@Builder
 @JsonInclude(JsonInclude.Include.NON_NULL)
 public class BookingResponse {
 

--- a/api-booking/src/main/java/com/wingtrip/booking/model/BookingStatus.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/model/BookingStatus.java
@@ -2,7 +2,6 @@ package com.wingtrip.booking.model;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
-import lombok.Setter;
 
 @Getter
 @AllArgsConstructor

--- a/api-booking/src/main/java/com/wingtrip/booking/repository/BookingRepository.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/repository/BookingRepository.java
@@ -26,10 +26,10 @@ public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
     // (Opcional) Filtro flexible para futuras mejoras
     @Query("""
     SELECT b FROM BookingEntity b
-    WHERE (:userId IS NULL OR b.userId = :userId)
-    AND (:status IS NULL OR b.bookingStatus = :status)
-    AND (:from IS NULL OR b.travelDate >= :from)
-    AND (:to IS NULL OR b.travelDate <= :to)
+    WHERE (userId IS NULL OR b.userId = userId)
+    AND (status IS NULL OR b.bookingStatus = status)
+    AND (from IS NULL OR b.travelDate >= from)
+    AND (to IS NULL OR b.travelDate <= to)
 """)
     List<BookingEntity> findAllWithFilters(
             @Param("userId") Long userId,

--- a/api-booking/src/main/java/com/wingtrip/booking/repository/BookingRepository.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/repository/BookingRepository.java
@@ -26,10 +26,10 @@ public interface BookingRepository extends JpaRepository<BookingEntity, Long> {
     // (Opcional) Filtro flexible para futuras mejoras
     @Query("""
     SELECT b FROM BookingEntity b
-    WHERE (userId IS NULL OR b.userId = userId)
-    AND (status IS NULL OR b.bookingStatus = status)
-    AND (from IS NULL OR b.travelDate >= from)
-    AND (to IS NULL OR b.travelDate <= to)
+    WHERE (:userId IS NULL OR b.userId = :userId)
+    AND (:status IS NULL OR b.bookingStatus = :status)
+    AND (:from IS NULL OR b.travelDate >= :from)
+    AND (:to IS NULL OR b.travelDate <= :to)
 """)
     List<BookingEntity> findAllWithFilters(
             @Param("userId") Long userId,

--- a/api-booking/src/main/java/com/wingtrip/booking/service/impl/BookingServiceImpl.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/service/impl/BookingServiceImpl.java
@@ -276,6 +276,6 @@ public class BookingServiceImpl implements BookingService {
 
 
     private String generateBookingReference() {
-        return "BK-" + UUID.randomUUID().toString().substring(0, 8).toUpperCase();
+        return "WT" + UUID.randomUUID().toString().substring(0, 6).toUpperCase();
     }
 }

--- a/api-booking/src/main/java/com/wingtrip/booking/service/impl/BookingServiceImpl.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/service/impl/BookingServiceImpl.java
@@ -7,6 +7,7 @@ import com.wingtrip.booking.model.BookingEntity;
 import com.wingtrip.booking.model.BookingStatus;
 import com.wingtrip.booking.repository.BookingRepository;
 import com.wingtrip.booking.service.BookingService;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -18,6 +19,7 @@ import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
 @Service
+@Transactional
 public class BookingServiceImpl implements BookingService {
 
     private final BookingRepository bookingRepository;

--- a/api-booking/src/main/resources/bootstrap.yml
+++ b/api-booking/src/main/resources/bootstrap.yml
@@ -22,3 +22,15 @@ spring:
       deserialization:
         FAIL_ON_UNKNOWN_PROPERTIES: false
 
+  springdoc:
+    api-docs:
+      path: /v3/api-docs
+      enabled: true
+    swagger-ui:
+      path: /swagger-ui.html
+      enabled: true
+    show-actuator: true
+    packages-to-scan: com.wingtrip.booking.controller
+    default-consumes-media-type: application/json
+    default-produces-media-type: application/json
+

--- a/api-booking/src/main/resources/bootstrap.yml
+++ b/api-booking/src/main/resources/bootstrap.yml
@@ -22,19 +22,3 @@ spring:
       deserialization:
         FAIL_ON_UNKNOWN_PROPERTIES: false
 
-  springdoc:
-    api-docs:
-      path: /v3/api-docs
-      enabled: true
-    swagger-ui:
-      path: /swagger-ui.html
-      enabled: true
-    show-actuator: true
-    packages-to-scan: com.wingtrip.booking.controller
-    default-consumes-media-type: application/json
-    default-produces-media-type: application/json
-
-  eureka:
-    client:
-      serviceUrl:
-        defaultZone: http://eureka-server:8761/eureka/

--- a/api-booking/src/main/resources/data.sql
+++ b/api-booking/src/main/resources/data.sql
@@ -1,4 +1,4 @@
-INSERT INTO booking (booking_reference, user_id, flight_id, payment_id, travel_date, return_date, adult_passengers, child_passengers, infant_passengers, total_amount, currency, booking_status, special_request, booking_notes, expires_at)
+INSERT INTO booking (booking_reference, user_id, flight_id, payment_id, travel_date, return_date, adult_passengers, child_passengers, infant_passengers, total_amount, currency, booking_status, special_requests, booking_notes, expires_at)
 VALUES
 ('WT001234', 1, 101, 1001, '2025-08-15', '2025-08-22', 2, 0, 0, 450.00, 'USD', 'CONFIRMED', 'Window seats preferred', 'Corporate booking', NULL),
 ('WT001235', 2, 102, NULL, '2025-08-20', NULL, 1, 1, 0, 320.50, 'USD', 'PENDING', 'Vegetarian meal', 'Family trip', '2025-07-25 10:00:00'),

--- a/api-booking/src/main/resources/schema.sql
+++ b/api-booking/src/main/resources/schema.sql
@@ -1,7 +1,5 @@
-CREATE DATABASE IF NOT EXISTS `booking_db`;
-USE `booking_db`;
-
 DROP TABLE IF EXISTS `booking`;
+
 CREATE TABLE `booking` (
         `booking_id` BIGINT NOT NULL AUTO_INCREMENT,
         `booking_reference` VARCHAR(10) UNIQUE NOT NULL,
@@ -19,9 +17,9 @@ CREATE TABLE `booking` (
         `booking_notes` TEXT,
         `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        `expires_at` TIMESTAMP,
-        `user_id` BIGINT NOT NULL,
-        `flight_id` BIGINT NOT NULL,
-        `payment_id` BIGINT NOT NULL,
-        PRIMARY KEY (`booking_id`)
+	`expires_at` TIMESTAMP,
+	`user_id` BIGINT NOT NULL,
+	`flight_id` BIGINT NOT NULL,
+	`payment_id` BIGINT,
+	PRIMARY KEY (`booking_id`)
 );

--- a/api-booking/src/main/resources/schema.sql
+++ b/api-booking/src/main/resources/schema.sql
@@ -4,13 +4,13 @@ USE `booking_db`;
 DROP TABLE IF EXISTS `booking`;
 CREATE TABLE `booking` (
         `booking_id` BIGINT NOT NULL AUTO_INCREMENT,
-        `booking_reference` VARCHAR(10) UNIQUE NOT NULL, --wt001234
+        `booking_reference` VARCHAR(10) UNIQUE NOT NULL,
         `booking_date` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         `travel_date` DATE NOT NULL,
-        `return_date` DATE, --Null si es solo un día
+        `return_date` DATE,
         `adult_passengers` INT DEFAULT 1,
-        `child_passengers` INT DEFAULT 0, --2 a 11 años
-        `infant_passengers` INT DEFAULT 0, --0 a 23 meses
+        `child_passengers` INT DEFAULT 0,
+        `infant_passengers` INT DEFAULT 0,
         `total_passengers` INT GENERATED ALWAYS AS (adult_passengers + child_passengers + infant_passengers),
         `total_amount` DECIMAL(10,2) NOT NULL,
         `currency` VARCHAR(3) DEFAULT 'USD',
@@ -19,7 +19,7 @@ CREATE TABLE `booking` (
         `booking_notes` TEXT,
         `created_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
         `updated_at` TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
-        `expires_at` TIMESTAMP, --para reservas temporales
+        `expires_at` TIMESTAMP,
         `user_id` BIGINT NOT NULL,
         `flight_id` BIGINT NOT NULL,
         `payment_id` BIGINT NOT NULL,

--- a/api-booking/src/test/java/com/wingtrip/booking/controller/BookingControllerTest.java
+++ b/api-booking/src/test/java/com/wingtrip/booking/controller/BookingControllerTest.java
@@ -1,0 +1,190 @@
+package com.wingtrip.booking.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.wingtrip.booking.controller.mapper.BookingMapper;
+import com.wingtrip.booking.controller.request.CreateBookingRequest;
+import com.wingtrip.booking.controller.response.BookingResponse;
+import com.wingtrip.booking.dto.BookingDTO;
+import com.wingtrip.booking.exception.BookingNotFoundByIdException;
+import com.wingtrip.booking.exception.MessageCode;
+import com.wingtrip.booking.model.BookingStatus;
+import com.wingtrip.booking.service.impl.BookingServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+import java.util.Collections;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = BookingController.class, properties = {
+        "spring.cloud.config.enabled=false",
+        "spring.cloud.discovery.enabled=false",
+        "eureka.client.enabled=false",
+        "spring.autoconfigure.exclude=org.springframework.cloud.netflix.eureka.EurekaClientAutoConfiguration"
+})
+@AutoConfigureMockMvc(addFilters = false)
+class BookingControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockBean
+    private BookingServiceImpl bookingService;
+
+    @MockBean
+    private BookingMapper bookingMapper;
+
+    private BookingDTO commonDto;
+    private BookingResponse commonResponse;
+
+    @BeforeEach
+    void setUp() {
+        commonDto = BookingDTO.builder()
+                .bookingId(1L)
+                .bookingReference("REF-123")
+                .bookingStatus(BookingStatus.PENDING)
+                .build();
+
+        commonResponse = BookingResponse.builder()
+                .bookingId(1L)
+                .bookingReference("REF-123")
+                .bookingStatus(BookingStatus.PENDING)
+                .build();
+    }
+
+    @Test
+    void testCreateBooking_Success() throws Exception {
+        CreateBookingRequest request = new CreateBookingRequest();
+        request.setUserId(1L);
+        request.setFlightId(100L);
+        request.setTravelDate(LocalDate.now().plusDays(1));
+        request.setAdultPassengers(1);
+        request.setChildPassengers(0);
+        request.setInfantPassengers(0);
+
+        when(bookingMapper.toDTO(any(CreateBookingRequest.class))).thenReturn(commonDto);
+        when(bookingService.createBooking(any(BookingDTO.class))).thenReturn(commonDto);
+        when(bookingMapper.toResponse(any(BookingDTO.class))).thenReturn(commonResponse);
+
+        mockMvc.perform(post("/api/v1/booking/create")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.bookingId").value(1L));
+    }
+
+    @Test
+    void testFindById_Success() throws Exception {
+        when(bookingService.findById(1L)).thenReturn(commonDto);
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(get("/api/v1/booking/find/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bookingId").value(1L));
+    }
+
+    @Test
+    void testFindById_NotFound() throws Exception {
+        when(bookingService.findById(99L))
+                .thenThrow(new BookingNotFoundByIdException(MessageCode.BOOKING_NOT_FOUND_BY_ID));
+
+        mockMvc.perform(get("/api/v1/booking/find/99"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void testConfirmBooking_Success() throws Exception {
+        when(bookingService.findById(anyLong())).thenReturn(commonDto);
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(put("/api/v1/booking/confirm/1")
+                        .param("paymentId", "555"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testFindAllExpiredBookings_Success() throws Exception {
+        when(bookingService.findAllExpiredBookings()).thenReturn(Collections.singletonList(commonDto));
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(get("/api/v1/booking/expired"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$").isArray());
+    }
+
+    @Test
+    void testFindByReference_Success() throws Exception {
+        when(bookingService.findByReference("REF-123")).thenReturn(commonDto);
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(get("/api/v1/booking/find-by-reference/REF-123"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.bookingReference").value("REF-123"));
+    }
+
+    @Test
+    void testCancelBooking_Success() throws Exception {
+        // No necesitamos mockear el void de cancelBooking, Mockito lo ignora por defecto
+        when(bookingService.findById(1L)).thenReturn(commonDto);
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(put("/api/v1/booking/cancel/1"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testFindBookingsByUserId_Success() throws Exception {
+        when(bookingService.findBookingsByUserId(1L)).thenReturn(Collections.singletonList(commonDto));
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(get("/api/v1/booking/user/1"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].bookingId").value(1L));
+    }
+
+    @Test
+    void testFindBookingsByUserIdAndStatus_Success() throws Exception {
+        when(bookingService.findBookingsByUserIdAndStatus(1L, BookingStatus.PENDING))
+                .thenReturn(Collections.singletonList(commonDto));
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(get("/api/v1/booking/user/1/status")
+                        .param("status", "PENDING"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testMarkAsPaid_Success() throws Exception {
+        when(bookingService.findById(1L)).thenReturn(commonDto);
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(put("/api/v1/booking/mark-paid/1")
+                        .param("paymentId", "999"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    void testIsBookingExpired_Success() throws Exception {
+        when(bookingService.isBookingExpired(1L)).thenReturn(true);
+        when(bookingService.findById(1L)).thenReturn(commonDto);
+        when(bookingMapper.toResponse(any())).thenReturn(commonResponse);
+
+        mockMvc.perform(get("/api/v1/booking/is-expired/1"))
+                .andExpect(status().isOk());
+    }
+}
+

--- a/api-booking/src/test/java/com/wingtrip/booking/controller/mapper/BookingMapperTest.java
+++ b/api-booking/src/test/java/com/wingtrip/booking/controller/mapper/BookingMapperTest.java
@@ -1,0 +1,180 @@
+package com.wingtrip.booking.controller.mapper;
+
+import com.wingtrip.booking.controller.request.CreateBookingRequest;
+import com.wingtrip.booking.controller.request.UpdateBookingRequest;
+import com.wingtrip.booking.controller.response.BookingResponse;
+import com.wingtrip.booking.dto.BookingDTO;
+import com.wingtrip.booking.model.BookingStatus;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import java.time.LocalDate;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("BookingMapper Tests")
+class BookingMapperTest {
+
+    private BookingMapper bookingMapper;
+
+    private CreateBookingRequest createRequest;
+    private BookingDTO bookingDTO;
+    private BookingResponse bookingResponse;
+
+    @BeforeEach
+    void setUp() {
+        bookingMapper = new BookingMapperImpl();
+
+        createRequest = CreateBookingRequest.builder()
+                .userId(1L)
+                .flightId(101L)
+                .travelDate(LocalDate.of(2025, 8, 15))
+                .returnDate(LocalDate.of(2025, 8, 22))
+                .adultPassengers(2)
+                .childPassengers(0)
+                .infantPassengers(0)
+                .totalAmount(450.00)
+                .currency("USD")
+                .specialRequests("Window seats preferred")
+                .build();
+
+        bookingDTO = BookingDTO.builder()
+                .bookingId(1L)
+                .bookingReference("WT123456")
+                .userId(1L)
+                .flightId(101L)
+                .travelDate(LocalDate.of(2025, 8, 15))
+                .returnDate(LocalDate.of(2025, 8, 22))
+                .adultPassengers(2)
+                .childPassengers(0)
+                .infantPassengers(0)
+                .totalAmount(450.00)
+                .currency("USD")
+                .bookingStatus(BookingStatus.PENDING)
+                .specialRequests("Window seats preferred")
+                .build();
+
+        bookingResponse = BookingResponse.builder()
+                .bookingId(1L)
+                .bookingReference("WT123456")
+                .userId(1L)
+                .flightId(101L)
+                .travelDate(LocalDate.of(2025, 8, 15))
+                .returnDate(LocalDate.of(2025, 8, 22))
+                .adultPassengers(2)
+                .childPassengers(0)
+                .infantPassengers(0)
+                .totalAmount(450.00)
+                .currency("USD")
+                .bookingStatus(BookingStatus.PENDING)
+                .specialRequests("Window seats preferred")
+                .build();
+    }
+
+    @Test
+    @DisplayName("Should map CreateBookingRequest to BookingDTO successfully")
+    void testToDTO_Success() {
+        BookingDTO result = bookingMapper.toDTO(createRequest);
+
+        assertNotNull(result);
+        assertEquals(createRequest.getUserId(), result.getUserId());
+        assertEquals(createRequest.getFlightId(), result.getFlightId());
+        assertEquals(createRequest.getTravelDate(), result.getTravelDate());
+        assertEquals(createRequest.getReturnDate(), result.getReturnDate());
+        assertEquals(createRequest.getAdultPassengers(), result.getAdultPassengers());
+        assertEquals(createRequest.getCurrency(), result.getCurrency());
+    }
+
+    @Test
+    @DisplayName("Should map CreateBookingRequest to BookingDTO with null optional fields")
+    void testToDTO_WithNullFields() {
+        CreateBookingRequest requestWithNulls = CreateBookingRequest.builder()
+                .userId(1L)
+                .flightId(101L)
+                .travelDate(LocalDate.of(2025, 8, 15))
+                .adultPassengers(2)
+                .build();
+
+        BookingDTO result = bookingMapper.toDTO(requestWithNulls);
+
+        assertNotNull(result);
+        assertEquals(requestWithNulls.getUserId(), result.getUserId());
+        assertNull(result.getReturnDate());
+        assertNull(result.getSpecialRequests());
+    }
+
+    @Test
+    @DisplayName("Should map BookingDTO to BookingResponse successfully")
+    void testToResponse_Success() {
+        BookingResponse result = bookingMapper.toResponse(bookingDTO);
+
+        assertNotNull(result);
+        assertEquals(bookingDTO.getBookingId(), result.getBookingId());
+        assertEquals(bookingDTO.getBookingReference(), result.getBookingReference());
+        assertEquals(bookingDTO.getUserId(), result.getUserId());
+        assertEquals(bookingDTO.getFlightId(), result.getFlightId());
+        assertEquals(bookingDTO.getBookingStatus(), result.getBookingStatus());
+    }
+
+    @Test
+    @DisplayName("Should map BookingDTO to BookingResponse preserving all fields")
+    void testToResponse_AllFields() {
+        BookingResponse result = bookingMapper.toResponse(bookingDTO);
+
+        assertNotNull(result);
+        assertEquals(bookingDTO.getBookingId(), result.getBookingId());
+        assertEquals(bookingDTO.getBookingReference(), result.getBookingReference());
+        assertEquals(bookingDTO.getTravelDate(), result.getTravelDate());
+        assertEquals(bookingDTO.getReturnDate(), result.getReturnDate());
+        assertEquals(bookingDTO.getAdultPassengers(), result.getAdultPassengers());
+        assertEquals(bookingDTO.getChildPassengers(), result.getChildPassengers());
+        assertEquals(bookingDTO.getInfantPassengers(), result.getInfantPassengers());
+        assertEquals(bookingDTO.getTotalAmount(), result.getTotalAmount());
+        assertEquals(bookingDTO.getCurrency(), result.getCurrency());
+        assertEquals(bookingDTO.getSpecialRequests(), result.getSpecialRequests());
+    }
+
+    @Test
+    @DisplayName("Should handle null DTO gracefully")
+    void testToResponse_NullDTO() {
+        BookingResponse result = bookingMapper.toResponse(null);
+
+        assertNull(result, "MapStruct should return null when input is null instead of throwing exception");
+    }
+
+    @Test
+    @DisplayName("Should handle null request gracefully")
+    void testToDTO_NullRequest() {
+        BookingDTO result = bookingMapper.toDTO((CreateBookingRequest) null);
+
+        assertNull(result, "MapStruct should return null when input is null instead of throwing exception");
+    }
+
+    @Test
+    @DisplayName("Should map UpdateBookingRequest to BookingDTO successfully")
+    void testToDTO_Update_Success() {
+        UpdateBookingRequest updateRequest = UpdateBookingRequest.builder()
+                .travelDate(LocalDate.of(2025, 12, 1))
+                .returnDate(LocalDate.of(2025, 12, 15))
+                .adultPassengers(3)
+                .childPassengers(1)
+                .infantPassengers(0)
+                .specialRequests("Extra luggage")
+                .bookingNotes("Urgent update")
+                .build();
+
+        BookingDTO result = bookingMapper.toDTO(updateRequest);
+
+        assertNotNull(result);
+        assertEquals(updateRequest.getTravelDate(), result.getTravelDate());
+        assertEquals(updateRequest.getReturnDate(), result.getReturnDate());
+        assertEquals(updateRequest.getAdultPassengers(), result.getAdultPassengers());
+        assertEquals(updateRequest.getChildPassengers(), result.getChildPassengers());
+        assertEquals(updateRequest.getInfantPassengers(), result.getInfantPassengers());
+        assertEquals(updateRequest.getSpecialRequests(), result.getSpecialRequests());
+
+        assertEquals(updateRequest.getBookingNotes(), result.getBookingNotes());
+    }
+}
+

--- a/api-booking/src/test/java/com/wingtrip/booking/service/BookingServiceImplTest.java
+++ b/api-booking/src/test/java/com/wingtrip/booking/service/BookingServiceImplTest.java
@@ -1,0 +1,267 @@
+package com.wingtrip.booking.service;
+
+import com.wingtrip.booking.dto.BookingDTO;
+import com.wingtrip.booking.exception.*;
+import com.wingtrip.booking.model.BookingEntity;
+import com.wingtrip.booking.model.BookingStatus;
+import com.wingtrip.booking.repository.BookingRepository;
+import com.wingtrip.booking.service.impl.BookingServiceImpl;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayName("BookingServiceImpl Tests")
+class BookingServiceImplTest {
+
+    @Mock
+    private BookingRepository bookingRepository;
+
+    @InjectMocks
+    private BookingServiceImpl bookingService;
+
+    private BookingDTO bookingDTO;
+    private BookingEntity bookingEntity;
+
+    @BeforeEach
+    void setUp() {
+        bookingDTO = BookingDTO.builder()
+                .userId(1L)
+                .flightId(101L)
+                .travelDate(LocalDate.of(2025, 8, 15))
+                .returnDate(LocalDate.of(2025, 8, 22))
+                .adultPassengers(2)
+                .childPassengers(0)
+                .infantPassengers(0)
+                .totalAmount(450.00)
+                .currency("USD")
+                .specialRequests("Window seats preferred")
+                .bookingNotes("Test booking")
+                .build();
+
+        bookingEntity = BookingEntity.builder()
+                .bookingId(1L)
+                .bookingReference("WT123456")
+                .bookingDate(LocalDateTime.now())
+                .travelDate(LocalDate.of(2025, 8, 15))
+                .returnDate(LocalDate.of(2025, 8, 22))
+                .adultPassengers(2)
+                .childPassengers(0)
+                .infantPassengers(0)
+                .totalAmount(450.00)
+                .currency("USD")
+                .bookingStatus(BookingStatus.PENDING)
+                .specialRequests("Window seats preferred")
+                .bookingNotes("Test booking")
+                .expiresAt(LocalDateTime.now().plusMinutes(15))
+                .userId(1L)
+                .flightId(101L)
+                .build();
+    }
+
+    @Test
+    @DisplayName("Should create booking successfully")
+    void testCreateBooking_Success() throws BookingNotCreateException {
+        when(bookingRepository.save(any(BookingEntity.class))).thenReturn(bookingEntity);
+
+        BookingDTO result = bookingService.createBooking(bookingDTO);
+
+        assertNotNull(result);
+        assertEquals(bookingEntity.getBookingId(), result.getBookingId());
+        assertEquals(BookingStatus.PENDING, result.getBookingStatus());
+        verify(bookingRepository, times(1)).save(any(BookingEntity.class));
+    }
+
+    @Test
+    @DisplayName("Should throw exception when return date is before travel date")
+    void testCreateBooking_InvalidReturnDate() {
+        bookingDTO.setTravelDate(LocalDate.of(2025, 8, 22));
+        bookingDTO.setReturnDate(LocalDate.of(2025, 8, 15));
+
+        assertThrows(BookingNotCreateException.class, () -> {
+            bookingService.createBooking(bookingDTO);
+        });
+    }
+
+    @Test
+    @DisplayName("Should find booking by ID successfully")
+    void testFindById_Success() throws BookingNotFoundByIdException {
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(bookingEntity));
+
+        BookingDTO result = bookingService.findById(1L);
+
+        assertNotNull(result);
+        assertEquals(bookingEntity.getBookingId(), result.getBookingId());
+        verify(bookingRepository, times(1)).findById(1L);
+    }
+
+    @Test
+    @DisplayName("Should throw exception when booking not found by ID")
+    void testFindById_NotFound() {
+
+        when(bookingRepository.findById(999L)).thenReturn(Optional.empty());
+
+        assertThrows(BookingNotFoundByIdException.class, () -> {
+            bookingService.findById(999L);
+        });
+    }
+
+    @Test
+    @DisplayName("Should find booking by reference successfully")
+    void testFindByReference_Success() throws BookingNotFoundByReferenceException {
+
+        when(bookingRepository.findByBookingReference("WT123456")).thenReturn(Optional.of(bookingEntity));
+
+        BookingDTO result = bookingService.findByReference("WT123456");
+
+        assertNotNull(result);
+        assertEquals(bookingEntity.getBookingReference(), result.getBookingReference());
+        verify(bookingRepository, times(1)).findByBookingReference("WT123456");
+    }
+
+    @Test
+    @DisplayName("Should throw exception when booking not found by reference")
+    void testFindByReference_NotFound() {
+
+        when(bookingRepository.findByBookingReference("INVALID")).thenReturn(Optional.empty());
+
+        assertThrows(BookingNotFoundByReferenceException.class, () -> {
+            bookingService.findByReference("INVALID");
+        });
+    }
+
+    @Test
+    @DisplayName("Should confirm booking successfully")
+    void testConfirmBooking_Success() throws BookingNotUpdateException, BookingNotFoundByIdException {
+
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(bookingEntity));
+        when(bookingRepository.save(any(BookingEntity.class))).thenReturn(bookingEntity);
+
+        bookingService.confirmBooking(1L, 1001L);
+
+        verify(bookingRepository, times(1)).findById(1L);
+        verify(bookingRepository, times(1)).save(any(BookingEntity.class));
+    }
+
+    @Test
+    @DisplayName("Should cancel booking successfully")
+    void testCancelBooking_Success() throws BookingCannotBeCancelledException, BookingAlreadyCancelledException {
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(bookingEntity));
+        when(bookingRepository.save(any(BookingEntity.class))).thenReturn(bookingEntity);
+
+        bookingService.cancelBooking(1L);
+
+        verify(bookingRepository, times(1)).findById(1L);
+        verify(bookingRepository, times(1)).save(any(BookingEntity.class));
+    }
+
+    @Test
+    @DisplayName("Should throw exception when cancelling already cancelled booking")
+    void testCancelBooking_AlreadyCancelled() {
+        bookingEntity.setBookingStatus(BookingStatus.CANCELLED);
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(bookingEntity));
+
+        assertThrows(BookingAlreadyCancelledException.class, () -> {
+            bookingService.cancelBooking(1L);
+        });
+    }
+
+    @Test
+    @DisplayName("Should check if booking is expired correctly")
+    void testIsBookingExpired_True() {
+        bookingEntity.setExpiresAt(LocalDateTime.now().minusMinutes(5));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(bookingEntity));
+
+        boolean result = bookingService.isBookingExpired(1L);
+
+        assertTrue(result);
+    }
+
+    @Test
+    @DisplayName("Should check if booking is not expired correctly")
+    void testIsBookingExpired_False() {
+        bookingEntity.setExpiresAt(LocalDateTime.now().plusMinutes(10));
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(bookingEntity));
+
+        boolean result = bookingService.isBookingExpired(1L);
+
+        assertFalse(result);
+    }
+
+    @Test
+    @DisplayName("Should find bookings by user ID successfully")
+    void testFindBookingsByUserId_Success() throws UserBookingsNotFoundException {
+        List<BookingEntity> bookings = List.of(bookingEntity);
+        when(bookingRepository.findByUserId(1L)).thenReturn(bookings);
+
+        List<BookingDTO> result = bookingService.findBookingsByUserId(1L);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        assertEquals(1, result.size());
+        verify(bookingRepository, times(1)).findByUserId(1L);
+    }
+
+    @Test
+    @DisplayName("Should throw exception when no bookings found for user")
+    void testFindBookingsByUserId_NotFound() {
+        when(bookingRepository.findByUserId(999L)).thenReturn(List.of());
+
+        assertThrows(UserBookingsNotFoundException.class, () -> {
+            bookingService.findBookingsByUserId(999L);
+        });
+    }
+
+    @Test
+    @DisplayName("Should find bookings by user ID and status successfully")
+    void testFindBookingsByUserIdAndStatus_Success() throws UserBookingsNotFoundException {
+        List<BookingEntity> bookings = List.of(bookingEntity);
+        when(bookingRepository.findByUserIdAndBookingStatus(1L, BookingStatus.PENDING))
+                .thenReturn(bookings);
+
+        List<BookingDTO> result = bookingService.findBookingsByUserIdAndStatus(1L, BookingStatus.PENDING);
+
+        assertNotNull(result);
+        assertFalse(result.isEmpty());
+        verify(bookingRepository, times(1)).findByUserIdAndBookingStatus(1L, BookingStatus.PENDING);
+    }
+
+    @Test
+    @DisplayName("Should mark booking as paid successfully")
+    void testMarkAsPaid_Success() throws BookingNotUpdateException, BookingNotFoundByIdException {
+        when(bookingRepository.findById(1L)).thenReturn(Optional.of(bookingEntity));
+        when(bookingRepository.save(any(BookingEntity.class))).thenReturn(bookingEntity);
+
+        bookingService.markAsPaid(1L, 1001L);
+
+        verify(bookingRepository, times(1)).findById(1L);
+        verify(bookingRepository, times(1)).save(any(BookingEntity.class));
+    }
+
+    @Test
+    @DisplayName("Should find all expired bookings")
+    void testFindAllExpiredBookings() {
+        List<BookingEntity> expiredBookings = List.of(bookingEntity);
+        when(bookingRepository.findByExpiresAtBefore(any(LocalDateTime.class)))
+                .thenReturn(expiredBookings);
+
+        List<BookingDTO> result = bookingService.findAllExpiredBookings();
+
+        assertNotNull(result);
+        verify(bookingRepository, times(1)).findByExpiresAtBefore(any(LocalDateTime.class));
+    }
+}
+

--- a/api-booking/src/test/resources/application-test.yml
+++ b/api-booking/src/test/resources/application-test.yml
@@ -1,0 +1,28 @@
+spring:
+  application:
+    name: api-booking
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+    show-sql: false
+  cloud:
+    config:
+      enabled: false
+    loadbalancer:
+      enabled: false
+
+eureka:
+  client:
+    enabled: false
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health

--- a/api-gateway/Dockerfile
+++ b/api-gateway/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 WORKDIR /app
 COPY target/*.jar app.jar
 EXPOSE 8080

--- a/api-user/Dockerfile
+++ b/api-user/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 WORKDIR /app
 COPY target/*.jar app.jar
 EXPOSE 8080

--- a/config-server/Dockerfile
+++ b/config-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY target/*.jar app.jar

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,8 +9,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD}
       MYSQL_DATABASE: 'user_db'
-      MYSQL_USER: ${DATABASE_USERNAME}
-      MYSQL_PASSWORD: ${DATABASE_PASSWORD}
+      MYSQL_USER: ${USER_DB_USER}
+      MYSQL_PASSWORD: ${USER_DB_PASS}
     ports:
       - '3310:3306'
     volumes:
@@ -34,8 +34,8 @@ services:
     environment:
       MYSQL_ROOT_PASSWORD: ${DATABASE_ROOT_PASSWORD}
       MYSQL_DATABASE: 'booking_db'
-      MYSQL_BOOKING: ${DATABASE_USERNAME}
-      MYSQL_PASSWORD: ${DATABASE_PASSWORD}
+      MYSQL_USER: ${BOOKING_DB_USER}
+      MYSQL_PASSWORD: ${BOOKING_DB_PASS}
     ports:
       - '3311:3306'
     volumes:
@@ -214,4 +214,5 @@ services:
 
 volumes:
   mysql-user-data:
+  mysql-booking-data:
   rabbitmq-data:

--- a/eureka-server/Dockerfile
+++ b/eureka-server/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:17-jdk-slim
+FROM eclipse-temurin:17-jdk
 RUN apt-get update && apt-get install -y wget && rm -rf /var/lib/apt/lists/*
 WORKDIR /app
 COPY target/*.jar app.jar


### PR DESCRIPTION
## ¿Qué incluye este PR?

### Implementación completa de api-booking

**Service Layer (BookingServiceImpl)**
- createBooking → genera referencia única (WT + UUID), expira en 15 min
- updateBooking → valida que no esté cancelada antes de actualizar
- findById / findByReference → búsqueda individual
- confirmBooking / cancelBooking → gestión de estados
- isBookingExpired → verificación de expiración por fecha
- markAsExpired / markAsPaid → transiciones de estado
- findBookingsByUserId → listado por usuario
- findBookingsByUserIdAndStatus → filtro por estado (PENDING, CANCELLED, etc.)
- findExpiredBookingsByUserId / findAllExpiredBookings → gestión de expiradas

**Controller (BookingController)**
- POST   /api/v1/booking/create
- PUT    /api/v1/booking/update/{bookingId}
- GET    /api/v1/booking/find/{bookingId}
- GET    /api/v1/booking/find-by-reference/{bookingReference}
- PUT    /api/v1/booking/confirm/{bookingId}
- PUT    /api/v1/booking/cancel/{bookingId}
- GET    /api/v1/booking/is-expired/{bookingId}
- GET    /api/v1/booking/user/{userId}
- GET    /api/v1/booking/user/{userId}/status
- GET    /api/v1/booking/user/{userId}/cancelled
- GET    /api/v1/booking/user/{userId}/pending
- GET    /api/v1/booking/user/{userId}/expired
- GET    /api/v1/booking/expired
- PUT    /api/v1/booking/mark-expired/{bookingId}
- PUT    /api/v1/booking/mark-paid/{bookingId}

### Estados de reserva manejados
PENDING → CONFIRMED → PAID → CANCELLED / EXPIRED

### Testing
- Tests unitarios con JUnit 5 + Mockito
- Pruebas de integración con Postman
- Cobertura JaCoCo: 67% (excluyendo DTOs, models y configs)

### Configuración agregada
- JaCoCo plugin para reporte de cobertura de código
- Maven Surefire para reportes XML