### PR TITLE
fix(api-booking): change totalAmount from Double to BigDecimal

### DIFF
--- a/api-booking/src/main/java/com/wingtrip/booking/controller/request/CreateBookingRequest.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/request/CreateBookingRequest.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 @Data
@@ -31,7 +32,7 @@ public class CreateBookingRequest {
 
     private int infantPassengers;
 
-    private Double totalAmount;
+    private BigDecimal totalAmount;
 
     private String currency; // Opcional, default "USD"
 

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingListResponse.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingListResponse.java
@@ -5,6 +5,7 @@ import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -19,7 +20,7 @@ public class BookingListResponse {
     private LocalDate travelDate;
     private LocalDate returnDate;
     private int totalPassengers;
-    private Double totalAmount;
+    private BigDecimal totalAmount;
     private String currency;
     private BookingStatus bookingStatus;
 

--- a/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingResponse.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/controller/response/BookingResponse.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -27,7 +28,7 @@ public class BookingResponse {
     private int childPassengers;
     private int infantPassengers;
     private int totalPassengers;
-    private Double totalAmount;
+    private BigDecimal totalAmount;
     private String currency;
     private String specialRequests;
     private String bookingNotes;

--- a/api-booking/src/main/java/com/wingtrip/booking/dto/BookingDTO.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/dto/BookingDTO.java
@@ -7,6 +7,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -25,7 +26,7 @@ public class BookingDTO {
     private int childPassengers;
     private int infantPassengers;
     private int totalPassengers;
-    private Double totalAmount;
+    private BigDecimal totalAmount;
     private String currency;
     private BookingStatus bookingStatus;
     private String specialRequests;

--- a/api-booking/src/main/java/com/wingtrip/booking/model/BookingEntity.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/model/BookingEntity.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 
@@ -47,8 +48,8 @@ public class BookingEntity {
     @Column(name = "total_passengers", insertable = false, updatable = false)
     private int totalPassengers;
 
-    @Column(name = "total_amount")
-    private Double totalAmount;
+    @Column(name = "total_amount", precision = 10, scale = 2)
+    private BigDecimal totalAmount;
 
     @Column(name = "currency")
     private String currency;

--- a/api-booking/src/test/java/com/wingtrip/booking/controller/mapper/BookingMapperTest.java
+++ b/api-booking/src/test/java/com/wingtrip/booking/controller/mapper/BookingMapperTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -34,7 +35,7 @@ class BookingMapperTest {
                 .adultPassengers(2)
                 .childPassengers(0)
                 .infantPassengers(0)
-                .totalAmount(450.00)
+                .totalAmount(new BigDecimal("450.00"))
                 .currency("USD")
                 .specialRequests("Window seats preferred")
                 .build();
@@ -49,7 +50,7 @@ class BookingMapperTest {
                 .adultPassengers(2)
                 .childPassengers(0)
                 .infantPassengers(0)
-                .totalAmount(450.00)
+                .totalAmount(new BigDecimal("450.00"))
                 .currency("USD")
                 .bookingStatus(BookingStatus.PENDING)
                 .specialRequests("Window seats preferred")
@@ -65,7 +66,7 @@ class BookingMapperTest {
                 .adultPassengers(2)
                 .childPassengers(0)
                 .infantPassengers(0)
-                .totalAmount(450.00)
+                .totalAmount(new BigDecimal("450.00"))
                 .currency("USD")
                 .bookingStatus(BookingStatus.PENDING)
                 .specialRequests("Window seats preferred")

--- a/api-booking/src/test/java/com/wingtrip/booking/service/BookingServiceImplTest.java
+++ b/api-booking/src/test/java/com/wingtrip/booking/service/BookingServiceImplTest.java
@@ -14,6 +14,7 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
@@ -46,7 +47,7 @@ class BookingServiceImplTest {
                 .adultPassengers(2)
                 .childPassengers(0)
                 .infantPassengers(0)
-                .totalAmount(450.00)
+                .totalAmount(new BigDecimal("450.00"))
                 .currency("USD")
                 .specialRequests("Window seats preferred")
                 .bookingNotes("Test booking")
@@ -61,7 +62,7 @@ class BookingServiceImplTest {
                 .adultPassengers(2)
                 .childPassengers(0)
                 .infantPassengers(0)
-                .totalAmount(450.00)
+                .totalAmount(new BigDecimal("450.00"))
                 .currency("USD")
                 .bookingStatus(BookingStatus.PENDING)
                 .specialRequests("Window seats preferred")


### PR DESCRIPTION
## ¿Qué incluye este PR?

### Fix de tipo de dato totalAmount

**Problema**
totalAmount estaba definido como Double en api-booking, 
causando incompatibilidad de tipos con api-payment que usa BigDecimal,
lo que generaría conflictos en la cola de mensajería RabbitMQ.

**Solución**
Cambio de Double a BigDecimal en:
- BookingEntity
- BookingDTO
- CreateBookingRequest
- BookingResponse
- BookingListResponse
- Tests actualizados (BookingMapperTest, BookingServiceImplTest)

### Testing
- 34 tests pasando sin fallos
- Sin cambios en funcionalidad