### PR TITLE
feat(api-payment): add Resilience4j Circuit Breaker, Retry and RateLimiter

### DIFF
--- a/api-payment/src/main/java/com/wingtrip/payment/config/Resilience4jConfig.java
+++ b/api-payment/src/main/java/com/wingtrip/payment/config/Resilience4jConfig.java
@@ -1,0 +1,37 @@
+package com.wingtrip.payment.config;
+
+import io.github.resilience4j.circuitbreaker.CircuitBreakerConfig;
+import io.github.resilience4j.timelimiter.TimeLimiterConfig;
+import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JCircuitBreakerFactory;
+import org.springframework.cloud.circuitbreaker.resilience4j.Resilience4JConfigBuilder;
+import org.springframework.cloud.client.circuitbreaker.Customizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import java.time.Duration;
+
+@Configuration
+public class Resilience4jConfig {
+
+    @Bean
+    public Customizer<Resilience4JCircuitBreakerFactory> globalCustomConfiguration() {
+
+        CircuitBreakerConfig circuitBreakerConfig = CircuitBreakerConfig.custom()
+                .failureRateThreshold(50)
+                .waitDurationInOpenState(Duration.ofMillis(5000))
+                .slidingWindowSize(10)
+                .minimumNumberOfCalls(5)
+                .permittedNumberOfCallsInHalfOpenState(3)
+                .automaticTransitionFromOpenToHalfOpenEnabled(true)
+                .build();
+
+        TimeLimiterConfig timeLimiterConfig = TimeLimiterConfig.custom()
+                .timeoutDuration(Duration.ofSeconds(3))
+                .build();
+
+        return factory -> factory.configureDefault(id -> new Resilience4JConfigBuilder(id)
+                .timeLimiterConfig(timeLimiterConfig)
+                .circuitBreakerConfig(circuitBreakerConfig)
+                .build());
+    }
+}

--- a/api-payment/src/main/java/com/wingtrip/payment/service/impl/PaymentServiceImpl.java
+++ b/api-payment/src/main/java/com/wingtrip/payment/service/impl/PaymentServiceImpl.java
@@ -6,6 +6,9 @@ import com.wingtrip.payment.model.PaymentEntity;
 import com.wingtrip.payment.model.PaymentStatus;
 import com.wingtrip.payment.repository.PaymentRepository;
 import com.wingtrip.payment.service.PaymentService;
+import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
+import io.github.resilience4j.ratelimiter.annotation.RateLimiter;
+import io.github.resilience4j.retry.annotation.Retry;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -89,6 +92,9 @@ public class PaymentServiceImpl implements PaymentService {
                 .collect(Collectors.toList());
     }
 
+    @CircuitBreaker(name = "paymentService", fallbackMethod = "processPaymentFallback")
+    @Retry(name = "paymentService")
+    @RateLimiter(name = "paymentService")
     @Override
     public PaymentDTO processPayment(Long paymentId) throws PaymentNotFoundException, PaymentAlreadyProcessedException, PaymentFailedException {
         PaymentEntity entity = paymentRepository.findById(paymentId)
@@ -112,6 +118,13 @@ public class PaymentServiceImpl implements PaymentService {
         }
     }
 
+    public PaymentDTO processPaymentFallback(Long paymentId, Exception ex) throws PaymentFailedException {
+        throw new PaymentFailedException(MessageCode.PAYMENT_FAILED);
+    }
+
+    @CircuitBreaker(name = "paymentService", fallbackMethod = "refundPaymentFallback")
+    @Retry(name = "paymentService")
+    @RateLimiter(name = "paymentService")
     @Override
     public PaymentDTO refundPayment(Long paymentId) throws PaymentNotFoundException, PaymentAlreadyRefundedException, PaymentCannotBeRefundedException {
         PaymentEntity entity = paymentRepository.findById(paymentId)
@@ -129,6 +142,10 @@ public class PaymentServiceImpl implements PaymentService {
         entity.setUpdatedAt(LocalDateTime.now());
         PaymentEntity updated = paymentRepository.save(entity);
         return new PaymentDTO(updated);
+    }
+
+    public PaymentDTO refundPaymentFallback(Long paymentId, Exception ex) throws PaymentCannotBeRefundedException {
+        throw new PaymentCannotBeRefundedException(MessageCode.PAYMENT_CANNOT_BE_REFUNDED);
     }
 
     @Override


### PR DESCRIPTION
## ¿Qué incluye este PR?

### Resilience4j implementado en api-payment

**Patrones implementados**
- Circuit Breaker → abre el circuito si el servicio falla repetidamente
- Retry → reintenta 3 veces automáticamente ante fallos
- Rate Limiter → limita llamadas por segundo

**Métodos protegidos**
- processPayment → @CircuitBreaker + @Retry + @RateLimiter + fallback
- refundPayment  → @CircuitBreaker + @Retry + @RateLimiter + fallback

**Configuración**
- Resilience4jConfig.java → configuración global del Circuit Breaker
- failureRateThreshold: 50%
- waitDurationInOpenState: 5000ms
- slidingWindowSize: 10
- minimumNumberOfCalls: 5

**Pruebas**
- 42 tests pasando sin fallos
- Verificado en Docker con Postman
- Retry confirmado en logs (3 intentos por llamada)

### Pendiente en próxima rama
- feature/api-payment-rabbitmq → cola de mensajería con api-booking