### PR TITLE
feat(rabbitmq): add payment event queue between api-payment and api-booking

### DIFF
--- a/api-booking/pom.xml
+++ b/api-booking/pom.xml
@@ -74,6 +74,12 @@
             <artifactId>spring-cloud-starter-loadbalancer</artifactId>
         </dependency>
 
+        <!-- RabbitMQ -->
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-amqp</artifactId>
+        </dependency>
+
         <!-- Database Dependencies -->
         <dependency>
             <groupId>com.mysql</groupId>

--- a/api-booking/src/main/java/com/wingtrip/booking/config/RabbitMQConfig.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/config/RabbitMQConfig.java
@@ -1,0 +1,48 @@
+package com.wingtrip.booking.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String PAYMENT_EXCHANGE = "payment.exchange";
+    public static final String PAYMENT_QUEUE = "payment.events";
+    public static final String PAYMENT_ROUTING_KEY = "payment.processed";
+
+    @Bean
+    public TopicExchange paymentExchange() {
+        return new TopicExchange(PAYMENT_EXCHANGE);
+    }
+
+    @Bean
+    public Queue paymentQueue() {
+        return QueueBuilder.durable(PAYMENT_QUEUE).build();
+    }
+
+    @Bean
+    public Binding paymentBinding(Queue paymentQueue, TopicExchange paymentExchange) {
+        return BindingBuilder
+                .bind(paymentQueue)
+                .to(paymentExchange)
+                .with(PAYMENT_ROUTING_KEY);
+    }
+
+    @Bean
+    public MessageConverter jsonMessageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate template = new RabbitTemplate(connectionFactory);
+        template.setMessageConverter(jsonMessageConverter());
+        return template;
+    }
+}

--- a/api-booking/src/main/java/com/wingtrip/booking/consumer/PaymentEventConsumer.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/consumer/PaymentEventConsumer.java
@@ -1,0 +1,37 @@
+package com.wingtrip.booking.consumer;
+import com.wingtrip.booking.config.RabbitMQConfig;
+import com.wingtrip.booking.event.PaymentEventDTO;
+import com.wingtrip.booking.exception.BookingNotUpdateException;
+import com.wingtrip.booking.service.BookingService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.annotation.RabbitListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PaymentEventConsumer {
+
+    private final BookingService bookingService;
+
+    @RabbitListener(queues = RabbitMQConfig.PAYMENT_QUEUE)
+    public void handlePaymentEvent(PaymentEventDTO event) {
+        log.info("Received payment event for bookingId: {} with status: {}",
+                event.getBookingId(), event.getPaymentStatus());
+
+        try {
+            if ("SUCCESS".equals(event.getPaymentStatus())) {
+                bookingService.markAsPaid(event.getBookingId(), event.getPaymentId());
+                log.info("Booking {} marked as PAID with paymentId: {}",
+                        event.getBookingId(), event.getPaymentId());
+            } else {
+                log.warn("Payment event received with status: {} for bookingId: {}",
+                        event.getPaymentStatus(), event.getBookingId());
+            }
+        } catch (BookingNotUpdateException e) {
+            log.error("Error updating booking {} after payment event: {}",
+                    event.getBookingId(), e.getMessage());
+        }
+    }
+}

--- a/api-booking/src/main/java/com/wingtrip/booking/event/PaymentEventDTO.java
+++ b/api-booking/src/main/java/com/wingtrip/booking/event/PaymentEventDTO.java
@@ -1,0 +1,20 @@
+package com.wingtrip.booking.event;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentEventDTO {
+
+    private Long paymentId;
+    private Long bookingId;
+    private BigDecimal amount;
+    private String currency;
+    private String paymentStatus;
+    private LocalDateTime paymentDate;
+}

--- a/api-payment/src/main/java/com/wingtrip/payment/config/RabbitMQConfig.java
+++ b/api-payment/src/main/java/com/wingtrip/payment/config/RabbitMQConfig.java
@@ -1,0 +1,47 @@
+package com.wingtrip.payment.config;
+
+import org.springframework.amqp.core.*;
+import org.springframework.amqp.rabbit.connection.ConnectionFactory;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.amqp.support.converter.Jackson2JsonMessageConverter;
+import org.springframework.amqp.support.converter.MessageConverter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class RabbitMQConfig {
+
+    public static final String PAYMENT_EXCHANGE = "payment.exchange";
+    public static final String PAYMENT_QUEUE = "payment.events";
+    public static final String PAYMENT_ROUTING_KEY = "payment.processed";
+
+    @Bean
+    public TopicExchange exchange() {
+        return new TopicExchange(PAYMENT_EXCHANGE);
+    }
+
+    @Bean
+    public Queue paymentQueue() {
+        return QueueBuilder.durable(PAYMENT_QUEUE).build();
+    }
+
+    @Bean
+    public Binding paymentBinding(Queue paymentQueue, TopicExchange paymentExchange) {
+        return BindingBuilder
+                .bind(paymentQueue)
+                .to(paymentExchange)
+                .with(PAYMENT_ROUTING_KEY);
+    }
+
+    @Bean
+    public MessageConverter messageConverter() {
+        return new Jackson2JsonMessageConverter();
+    }
+
+    @Bean
+    public RabbitTemplate rabbitTemplate(ConnectionFactory connectionFactory) {
+        RabbitTemplate rabbitTemplate = new RabbitTemplate(connectionFactory);
+        rabbitTemplate.setMessageConverter(messageConverter());
+        return rabbitTemplate;
+    }
+}

--- a/api-payment/src/main/java/com/wingtrip/payment/event/PaymentEventDTO.java
+++ b/api-payment/src/main/java/com/wingtrip/payment/event/PaymentEventDTO.java
@@ -1,0 +1,21 @@
+package com.wingtrip.payment.event;
+import com.wingtrip.payment.model.PaymentStatus;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class PaymentEventDTO {
+
+    private Long paymentId;
+    private Long bookingId;
+    private BigDecimal amount;
+    private String currency;
+    private PaymentStatus paymentStatus;
+    private LocalDateTime paymentDate;
+}

--- a/api-payment/src/main/java/com/wingtrip/payment/publisher/PaymentEventPublisher.java
+++ b/api-payment/src/main/java/com/wingtrip/payment/publisher/PaymentEventPublisher.java
@@ -1,0 +1,29 @@
+package com.wingtrip.payment.publisher;
+
+import com.wingtrip.payment.config.RabbitMQConfig;
+import com.wingtrip.payment.event.PaymentEventDTO;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class PaymentEventPublisher {
+
+    private final RabbitTemplate rabbitTemplate;
+
+    public void publishPaymentProcessed(PaymentEventDTO event) {
+        log.info("Publishing payment event for bookingId: {} with status: {}",
+                event.getBookingId(), event.getPaymentStatus());
+
+        rabbitTemplate.convertAndSend(
+                RabbitMQConfig.PAYMENT_EXCHANGE,
+                RabbitMQConfig.PAYMENT_ROUTING_KEY,
+                event
+        );
+
+        log.info("Payment event published successfully for bookingId: {}", event.getBookingId());
+    }
+}

--- a/api-payment/src/main/java/com/wingtrip/payment/service/impl/PaymentServiceImpl.java
+++ b/api-payment/src/main/java/com/wingtrip/payment/service/impl/PaymentServiceImpl.java
@@ -1,9 +1,11 @@
 package com.wingtrip.payment.service.impl;
 
 import com.wingtrip.payment.dto.PaymentDTO;
+import com.wingtrip.payment.event.PaymentEventDTO;
 import com.wingtrip.payment.exception.*;
 import com.wingtrip.payment.model.PaymentEntity;
 import com.wingtrip.payment.model.PaymentStatus;
+import com.wingtrip.payment.publisher.PaymentEventPublisher;
 import com.wingtrip.payment.repository.PaymentRepository;
 import com.wingtrip.payment.service.PaymentService;
 import io.github.resilience4j.circuitbreaker.annotation.CircuitBreaker;
@@ -24,6 +26,7 @@ import java.util.stream.Collectors;
 public class PaymentServiceImpl implements PaymentService {
 
     private final PaymentRepository paymentRepository;
+    private final PaymentEventPublisher paymentEventPublisher;
 
 
     @Override
@@ -109,6 +112,17 @@ public class PaymentServiceImpl implements PaymentService {
             entity.setPaymentDate(LocalDateTime.now());
             entity.setUpdatedAt(LocalDateTime.now());
             PaymentEntity updated = paymentRepository.save(entity);
+
+            PaymentEventDTO event = PaymentEventDTO.builder()
+                    .paymentId(updated.getPaymentId())
+                    .bookingId(updated.getBookingId())
+                    .amount(updated.getAmount())
+                    .currency(updated.getCurrency())
+                    .paymentStatus(updated.getPaymentStatus())
+                    .paymentDate(updated.getPaymentDate())
+                    .build();
+            paymentEventPublisher.publishPaymentProcessed(event);
+
             return new PaymentDTO(updated);
         } catch (Exception e) {
             entity.setPaymentStatus(PaymentStatus.FAILED);

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -189,6 +189,8 @@ services:
         condition: service_healthy
       eureka-server:
         condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
     ports:
       - "8082:8080"
     env_file:


### PR DESCRIPTION
## ¿Qué incluye este PR?

### Cola de mensajería RabbitMQ (api-payment → api-booking)

**Flujo implementado**
Cliente paga → api-payment procesa pago → publica evento en RabbitMQ → api-booking consume evento → booking se actualiza a PAID

**api-payment (Publisher)**
- RabbitMQConfig → exchange, queue y routing key
- PaymentEventDTO → objeto que viaja por la cola
- PaymentEventPublisher → publica el evento tras pago SUCCESS
- PaymentServiceImpl → integración del publisher en processPayment

**api-booking (Consumer)**
- RabbitMQConfig → configuración de la cola
- PaymentEventDTO → objeto que recibe de la cola
- PaymentEventConsumer → escucha la cola y llama markAsPaid

**Configuración**
- Exchange: payment.exchange (TopicExchange)
- Queue: payment.events (durable)
- Routing Key: payment.processed
- Mensajes serializados como JSON con Jackson2JsonMessageConverter

**Pruebas**
- Flujo completo verificado en Docker + Postman
- Booking actualizado a PAID con paymentId correcto tras procesar pago

**docker-compose**
- api-booking ahora depende de rabbitmq