### PR TITLE
chore: remove SonarQube inline suggestions from GlobalExceptionHandlerTest

### DIFF
--- a/api-flight/src/test/java/com/wingtrip/flight/exception/GlobalExceptionHandlerTest.java
+++ b/api-flight/src/test/java/com/wingtrip/flight/exception/GlobalExceptionHandlerTest.java
@@ -14,12 +14,11 @@ import org.springframework.http.ResponseEntity;
 import java.util.Map;
 import java.util.Objects;
 
-import static com.wingtrip.flight.exception.MessageCode.*;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 @ExtendWith(MockitoExtension.class)
-public class GlobalExceptionHandlerTest {
+class GlobalExceptionHandlerTest {
 
     @InjectMocks
     private GlobalExceptionHandler globalExceptionHandler;


### PR DESCRIPTION
## 🧹 chore: remove SonarQube inline suggestions from test class

### Description
Minor cleanup — removes SonarQube inline suggestions that were accidentally committed in PR #18.

### Changes
- Removed IDE inline suggestions from `GlobalExceptionHandlerTest`
- Changed `public class` to package-private `class` to follow project test conventions