### PR TITLE
feat(api-flight-details): add MongoDB and service to docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,6 +101,29 @@ services:
       interval: 10s
       start_period: 40s
 
+  mongodb-flight-details:
+    image: mongo:7.0
+    container_name: mongodb-flight-details
+    environment:
+      MONGO_INITDB_ROOT_USERNAME: ${MONGODB_USER}
+      MONGO_INITDB_ROOT_PASSWORD: ${MONGODB_PASSWORD}
+      MONGO_INITDB_DATABASE: 'flight_details_db'
+    ports:
+      - '27018:27017'
+    volumes:
+      - mongodb-flight-details-data:/data/db
+      - mongodb-flight-details-config:/data/configdb
+    env_file:
+      - .env
+    networks:
+      - wingtrip-network
+    healthcheck:
+      test: [ "CMD", "mongosh", "--authenticationDatabase", "admin", "-u", "${MONGODB_USER}", "-p", "${MONGODB_PASSWORD}", "--eval", "db.adminCommand('ping')" ]
+      timeout: 20s
+      retries: 10
+      interval: 10s
+      start_period: 40s
+
   config-server:
     build: ./config-server
     image: configserver:latest
@@ -301,6 +324,37 @@ services:
       start_period: 60s
     restart: on-failure
 
+  api-flight-details:
+    build: ./api-flight-details
+    container_name: api-flight-details
+    depends_on:
+      mongodb-flight-details:
+        condition: service_healthy
+      config-server:
+        condition: service_healthy
+      eureka-server:
+        condition: service_healthy
+    ports:
+      - "8085:8080"
+    env_file:
+      - .env
+    networks:
+      - wingtrip-network
+    environment:
+      - SPRING_PROFILES_ACTIVE=docker
+      - EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE=http://eureka-server:8761/eureka/
+      - EUREKA_CLIENT_FETCH_REGISTRY=true
+      - EUREKA_CLIENT_REGISTER_WITH_EUREKA=true
+      - EUREKA_INSTANCE_PREFER_IP_ADDRESS=true
+      - EUREKA_CLIENT_HEALTHCHECK_ENABLED=true
+    healthcheck:
+      test: [ "CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:8080/actuator/health" ]
+      timeout: 15s
+      retries: 5
+      interval: 30s
+      start_period: 60s
+    restart: on-failure
+
   api-gateway:
     build: ./api-gateway
     container_name: api-gateway
@@ -336,4 +390,6 @@ volumes:
   mysql-payment-data:
   mongodb-flight-data:
   mongodb-flight-config:
+  mongodb-flight-details-data:
+  mongodb-flight-details-config:
   rabbitmq-data:


### PR DESCRIPTION
## feat(api-flight-details): infrastructure setup

### Description
Infrastructure configuration for the api-flight-details microservice.

### Changes included
- Added `mongodb-flight-details` service in `docker-compose.yml` (port 27018)
- Added `api-flight-details` service in `docker-compose.yml` (port 8085)
- Added missing volumes `mongodb-flight-details-data` and `mongodb-flight-details-config`
- Added `api-flight-details.yml` in config-server repo

### Pending (next branch)
- [ ] `feature/api-flight-details-service` — Mapper, service layer, controller, unit tests